### PR TITLE
Remove unreached os.Exit(1)

### DIFF
--- a/ch6-web/ch6-01-introduction.md
+++ b/ch6-web/ch6-01-introduction.md
@@ -45,7 +45,6 @@ func main() {
     err := http.ListenAndServe(":8080", nil)
     if err != nil {
         log.Fatal(err)
-        os.Exit(1)
     }
 }
 


### PR DESCRIPTION
log.Fatal will auto invoke os.Exit

## Description

Typo fix 

## Designs

If it's a feature, please write your code designs here.

## Notes to reviewers

Review the following things, including but not limit to:

1. Design
2. Code (styles, magic...)