### PR TITLE
修改例子代码

### DIFF
--- a/ch1-basic/ch1-04-func-method-interface.md
+++ b/ch1-basic/ch1-04-func-method-interface.md
@@ -71,7 +71,6 @@ func Find(m map[int]int, key int) (value int, ok bool) {
 
 ```go
 func Inc() (v int) {
-	v = 42
 	defer func(){ v++ } ()
 	return 42
 }

--- a/ch1-basic/ch1-04-func-method-interface.md
+++ b/ch1-basic/ch1-04-func-method-interface.md
@@ -70,10 +70,10 @@ func Find(m map[int]int, key int) (value int, ok bool) {
 如果返回值命名了，可以通过名字来修改返回值，也可以通过`defer`语句在`return`语句之后修改返回值：
 
 ```go
-func Inc(x int) (v int) {
+func Inc() (v int) {
 	v = 42
 	defer func(){ v++ } ()
-	return v
+	return 42
 }
 ```
 


### PR DESCRIPTION
原例子
```go
func Inc(x int) (v int) {
        v = 42
        defer func(){ v++ } ()
        return v
}
```  
这里无法说明 `defer` 是在 `return` 之后执行的。因为即使 `v++` 发生在 `return` 之前也会导致最终结果加一。所以参考官方日志的[例子](https://blog.golang.org/defer-panic-and-recover)进行修改。

```go                                               
func Inc() (v int) {                                
        v = 42                                      
        defer func(){ v++ } ()                      
        return 42                                   
}                                                   
```

                                                