### PR TITLE
typo: `str` should be `s`

### DIFF
--- a/ch1-basic/ch1-03-array-string-and-slice.md
+++ b/ch1-basic/ch1-03-array-string-and-slice.md
@@ -268,7 +268,7 @@ fmt.Printf("%#v\n", string([]rune{'世', '界'})) // 世界
 ```go
 func forOnString(s string, forBody func(i int, r rune)) {
 	for i := 0; len(s) > 0; {
-    	r, size := utf8.DecodeRuneInString(str)
+    	r, size := utf8.DecodeRuneInString(s)
 		forBody(i, r)
     	s = s[size:]
 		i += size


### PR DESCRIPTION
## Description

type: `str` should be `s`

## Designs


## Notes to reviewers
