### PR TITLE
ch4-03-修正一个表达

### DIFF
--- a/ch4-rpc/ch4-03-netrpc-hack.md
+++ b/ch4-rpc/ch4-03-netrpc-hack.md
@@ -67,7 +67,7 @@ func (call *Call) done() {
 }
 ```
 
-从`Call.done`方法的实现可以得知`call.Done`管道会将输入的call原样返回。
+从`Call.done`方法的实现可以得知`call.Done`管道会将处理后的的call返回。
 
 ## 基于RPC实现Watch功能
 


### PR DESCRIPTION
> 	Reply         interface{} // The reply from the function (*struct).
> 	Error         error       // After completion, the error status.

发送的call的这两个域必有一个被修改了，所以call不是“原样”。

> 将输入的call原样返回

似乎不合适？ ！
