### PR TITLE
fixed code

### DIFF
--- a/ch4-rpc/ch4-02-pb-intro.md
+++ b/ch4-rpc/ch4-02-pb-intro.md
@@ -285,18 +285,16 @@ func (p *netrpcPlugin) buildServiceSpec(svc *descriptor.ServiceDescriptorProto) 
 
 ```go
 func (p *netrpcPlugin) genServiceCode(svc *descriptor.ServiceDescriptorProto) {
-	for _, svc := range file.Service {
-		spec := p.buildServiceSpec(svc)
+	spec := p.buildServiceSpec(svc)
 
-		var buf bytes.Buffer
-		t := template.Must(template.New("").Parse(tmplService))
-		err := t.Execute(&buf, spec)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		p.P(buf.String())
+	var buf bytes.Buffer
+	t := template.Must(template.New("").Parse(tmplService))
+	err := t.Execute(&buf, spec)
+	if err != nil {
+		log.Fatal(err)
 	}
+
+	p.P(buf.String())
 }
 ```
 


### PR DESCRIPTION
正文和附录不一致，且编译报错
正文：
>  func (p *netrpcPlugin) genServiceCode(svc *descriptor.ServiceDescriptorProto) {
> 	for _, svc := range file.Service {                  //《--------多出来的
> 		spec := p.buildServiceSpec(svc)
> 
> 		var buf bytes.Buffer
> 		t := template.Must(template.New("").Parse(tmplService))
> 		err := t.Execute(&buf, spec)
> 		if err != nil {
> 			log.Fatal(err)
> 		}
> 
> 		p.P(buf.String())
> 	}
> }

附录：

> func (p *netrpcPlugin) genServiceCode(svc *descriptor.ServiceDescriptorProto) {
> 	spec := p.buildServiceSpec(svc)
> 
> 	var buf bytes.Buffer
> 	t := template.Must(template.New("").Parse(tmplService))
> 	err := t.Execute(&buf, spec)
> 	if err != nil {
> 		log.Fatal(err)
> 	}
> 
> 	p.P(buf.String())
> }