### PR TITLE
cgo内存模型章节代码问题

### DIFF
--- a/ch2-cgo/ch2-07-memory.md
+++ b/ch2-cgo/ch2-07-memory.md
@@ -186,19 +186,6 @@ func (id *ObjectId) Free() interface{} {
 ```go
 package main
 
-/*
-export char* NewGoString(char* );
-export void FreeGoString(char* );
-export void PrintGoString(char* );
-
-void printString(const char* s) {
-	char* gs = NewGoString(s);
-	PrintGoString(gs);
-	FreeGoString(gs);
-}
-*/
-import "C"
-
 //export NewGoString
 func NewGoString(s *C.char) *C.char {
 	gs := C.GoString(s)
@@ -218,6 +205,20 @@ func PrintGoString(s *C.char) {
 	gs := id.Get().(string)
 	print(gs)
 }
+
+package main
+/*
+extern char* NewGoString(char* );
+extern void FreeGoString(char* );
+extern void PrintGoString(char* );
+
+void printString(const char* s) {
+	char* gs = NewGoString(s);
+	PrintGoString(gs);
+	FreeGoString(gs);
+}
+*/
+import "C"
 
 func main() {
 	C.printString("hello")

--- a/ch2-cgo/ch2-07-memory.md
+++ b/ch2-cgo/ch2-07-memory.md
@@ -90,7 +90,7 @@ void printString(const char* s) {
 import "C"
 
 func printString(s string) {
-	C.printString((*C.char)(unsafe.Pointer(&s[0])))
+	C.printString((*C.char)(C.CString(s)))
 }
 
 func main() {


### PR DESCRIPTION
提示：解决了什么问题，也可以讲下理由。
1. go中的string要使用`C.CString`转化为C可以使用的string。
2. c调go的时候要注意：如果调用的go函数处于某个c函数的函数体内部，则export的go函数需要在独立的go文件中才能编译成功