### PR TITLE
fixed code

### DIFF
--- a/ch4-rpc/ch4-04-grpc.md
+++ b/ch4-rpc/ch4-04-grpc.md
@@ -262,11 +262,11 @@ func main() {
 ```protobuf
 service PubsubService {
 	rpc Publish (String) returns (String);
-	rpc SubscribeTopic (String) returns (stream String);
+	rpc Subscribe (String) returns (stream String);
 }
 ```
 
-其中Publish是普通的RPC方法，SubscribeTopic则是一个单向的流服务。然后grpc插件会为服务端和客户端生成对应的接口：
+其中Publish是普通的RPC方法，Subscribe则是一个单向的流服务。然后grpc插件会为服务端和客户端生成对应的接口：
 
 ```go
 type PubsubServiceServer interface {
@@ -286,7 +286,7 @@ type HelloService_SubscribeServer interface {
 }
 ```
 
-因为SubscribeTopic是服务端的单向流，因此生成的HelloService_SubscribeServer接口中只有Send方法。
+因为Subscribe是服务端的单向流，因此生成的HelloService_SubscribeServer接口中只有Send方法。
 
 然后就可以实现发布和订阅服务了：
 
@@ -315,7 +315,7 @@ func (p *PubsubService) Publish(
 func (p *PubsubService) Subscribe(
 	arg *String, stream PubsubService_SubscribeServer,
 ) error {
-	ch := p.SubscribeTopic(func(v interface{}) bool {
+	ch := p.Subscribe(func(v interface{}) bool {
 		if key, ok := v.(string); ok {
 			if strings.Hasprefix(arg.GetValue()) {
 				return true

--- a/ch4-rpc/ch4-04-grpc.md
+++ b/ch4-rpc/ch4-04-grpc.md
@@ -346,11 +346,11 @@ func main() {
 
 	client := NewPubsubServiceClient(conn)
 
-	reply, err := client.Publish(context.Background(), &String{Value: "golang: hello Go"})
+	_, err = client.Publish(context.Background(), &String{Value: "golang: hello Go"})
 	if err != nil {
 		log.Fatal(err)
 	}
-	reply, err := client.Publish(context.Background(), &String{Value: "docker: hello Docker"})
+	_, err = client.Publish(context.Background(), &String{Value: "docker: hello Docker"})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
根据上下文SubscribeTopic改Subscribe比较合适

> service PubsubService {
> 	rpc Publish (String) returns (String);
> 	//rpc SubscribeTopic (String) returns (stream String);
> 	rpc Subscribe (String) returns (stream String);
> }

1，和Publish对称
2，后面定义的是Subscribe方法

> func (p *PubsubService) Subscribe
