### PR TITLE
fs.Lstat(p) to fs.fs.Lstat(p)

### DIFF
--- a/ch1-basic/ch1-06-goroutine.md
+++ b/ch1-basic/ch1-06-goroutine.md
@@ -376,7 +376,7 @@ type gatefs struct {
 func (fs gatefs) Lstat(p string) (os.FileInfo, error) {
 	fs.enter()
 	defer fs.leave()
-	return fs.Lstat(p)
+	return fs.fs.Lstat(p)
 }
 ```
 


### PR DESCRIPTION
 ```go
type gatefs struct {
	fs vfs.FileSystem
	gate
}

func (fs gatefs) Lstat(p string) (os.FileInfo, error) {
	fs.enter()
	defer fs.leave()
	return fs.Lstat(p)
}
```

源代码中的fs.Lstat(p)中会造成递归调用Lstat函数，应改为fs.fs.Lstat(p)才可正确调用gatefs类型中fs的Lstat方法。