### PR TITLE
Update ch1-03-array-string-and-slice.md

### DIFF
--- a/ch1-basic/ch1-03-array-string-and-slice.md
+++ b/ch1-basic/ch1-03-array-string-and-slice.md
@@ -279,7 +279,7 @@ fmt.Printf("%#v\n", string([]rune{'世', '界'})) // 世界
 ```go
 func forOnString(s string, forBody func(i int, r rune)) {
 	for i := 0; len(s) > 0; {
-		r, size := utf8.DecodeRuneInString(s)
+		r, size := utf8.DecodeRune(s)
 		forBody(i, r)
 		s = s[size:]
 		i += size


### PR DESCRIPTION
fix  `Cannot use 's' (type []byte) as type string`
Correct function is `DecodeRune`