### PR TITLE
Update ch2-02-basic.md

### DIFF
--- a/ch2-cgo/ch2-02-basic.md
+++ b/ch2-cgo/ch2-02-basic.md
@@ -121,7 +121,7 @@ package main
 #cgo linux CFLAGS: -DCGO_OS_LINUX=1
 
 #if defined(CGO_OS_WINDOWS)
-	static const char* os = "windows";
+	const char* os = "windows";
 #elif defined(CGO_OS_DARWIN)
 	static const char* os = "darwin";
 #elif defined(CGO_OS_LINUX)


### PR DESCRIPTION
在windows下， 有static的话 会报错。其它平台不知道。

```
# command-line-arguments
C:\Users\ADMINI~1\AppData\Local\Temp\go-build177025346\b001\_cgo_main.o:_cgo_main.c:(.data+0x0): undefined reference to `os'
collect2.exe: error: ld returned 1 exit status
```

提示：解决了什么问题，也可以讲下理由。
