### PR TITLE
Update ch2-03-cgo-types.md

### DIFF
--- a/ch2-cgo/ch2-03-cgo-types.md
+++ b/ch2-cgo/ch2-03-cgo-types.md
@@ -322,8 +322,9 @@ type SliceHeader struct {
 
 ```go
 /*
-static char arr[10];
-static char *s = "Hello";
+#include <string.h>
+char arr[10];
+char *s = "Hello";
 */
 import "C"
 import "fmt"
@@ -335,17 +336,18 @@ func main() {
 	arr0Hdr.Data = uintptr(unsafe.Pointer(&C.arr[0]))
 	arr0Hdr.Len = 10
 	arr0Hdr.Cap = 10
-
+	fmt.Printf("arr0Hdr:%T %[1]v\n", arr0Hdr)
 	// 通过切片语法转换
 	arr1 := (*[31]byte)(unsafe.Pointer(&C.arr[0]))[:10:10]
-
+	fmt.Println(arr1)
 	var s0 string
 	var s0Hdr = (*reflect.StringHeader)(unsafe.Pointer(&s0))
 	s0Hdr.Data = uintptr(unsafe.Pointer(C.s))
 	s0Hdr.Len = int(C.strlen(C.s))
-
+	fmt.Printf("s0Hdr:%T %[1]v\n", s0Hdr)
 	sLen := int(C.strlen(C.s))
-	s1 := string((*[31]byte)(unsafe.Pointer(&C.s[0]))[:sLen:sLen])
+	s1 := string((*[31]byte)(unsafe.Pointer(C.s))[:sLen:sLen])
+	fmt.Printf("s1:%T %[1]v   len:%d   GoString:%T %[3]v \n", s1, len(s1), C.GoString(C.s))
 }
 ```
 


### PR DESCRIPTION
提示找不到 C.strlen，所以需要包含 `<string.h>` 头文件。
另外 static 变量 在 Go 的C虚拟包里找不到，不知道为什么。
提示几个变量未引用，所以加几个打印，方便后面的朋友copy。


重点是这个问题。

`s1 := string((*[32]byte)(unsafe.Pointer(&C.s[0]))[:sLen:sLen]) `
会报错
`invalid operation: (*_Cvar_s)[0] (type *_Ctype_char does not support indexing)`

`C.s[0]   C.s `不支持索引。  
不知道作者是否测试过这句代码，的确编译不过去。理论上来说 char * 也是数组啊,希望有人能解惑一下。  

`fmt.Printf("%T %T\n", C.arr, C.s)` 结果是 `[10]main._Ctype_char *main._Ctype_char`  两个类型的确不一样。 那么问题来了，我如何才能索引到  `C.s` 第二个字节？

```
 go version
go version go1.11.2 windows/amd64
```

```
 go env
set GOARCH=amd64
set GOBIN=
set GOCACHE=C:\Users\Administrator\AppData\Local\go-build
set GOEXE=.exe
set GOFLAGS=
set GOHOSTARCH=amd64
set GOHOSTOS=windows
set GOOS=windows
set GOPATH=D:\gopath
set GOPROXY=
set GORACE=
set GOROOT=D:\Go
set GOTMPDIR=
set GOTOOLDIR=D:\Go\pkg\tool\windows_amd64
set GCCGO=gccgo
set CC=gcc
set CXX=g++
set CGO_ENABLED=1
set GOMOD=
set CGO_CFLAGS=-g -O2
set CGO_CPPFLAGS=
set CGO_CXXFLAGS=-g -O2
set CGO_FFLAGS=-g -O2
set CGO_LDFLAGS=-g -O2
set PKG_CONFIG=pkg-config
set GOGCCFLAGS=-m64 -mthreads -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=C:\Users\ADMINI~1\AppData\Local\Temp\go-build054670714=/tmp/go-build -gno-record-gcc-switches

```


