### PR TITLE
Update ch2-07-memory.md

### DIFF
--- a/ch2-cgo/ch2-07-memory.md
+++ b/ch2-cgo/ch2-07-memory.md
@@ -32,9 +32,9 @@ func freeByteSlice(p []byte) {
 
 func main() {
 	s := makeByteSlize(1<<32+1)
-	s[len[s]-1] = 1234
-	print(s[len[s]-1])
-	freeByteSlice(p)
+	s[len(s)-1] = 255
+	print(s[len(s)-1])
+	freeByteSlice(s)
 }
 ```
 


### PR DESCRIPTION
fix code.

byte 溢出   `constant 1234 overflows byte`

