### PR TITLE
Update ch3-05-control-flow.md

### DIFF
--- a/ch3-asm/ch3-05-control-flow.md
+++ b/ch3-asm/ch3-05-control-flow.md
@@ -214,7 +214,7 @@ LOOP_END:
 
 ```
 // func LoopAdd(cnt, v0, step int) int
-TEXT ·LoopAdd(SB), NOSPLIT, $0-32
+TEXT ·LoopAdd(SB),  $0-32
 	MOVQ cnt+0(FP), AX   // cnt
 	MOVQ v0+8(FP), BX    // v0/result
 	MOVQ step+16(FP), CX // step
@@ -225,12 +225,12 @@ LOOP_BEGIN:
 LOOP_IF:
 	CMPQ DX, AX          // compare i, cnt
 	JL   LOOP_BODY       // if i < cnt: goto LOOP_BODY
-	goto LOOP_END
+	JMP LOOP_END
 
 LOOP_BODY:
 	ADDQ $1, DX          // i++
 	ADDQ CX, BX          // result += step
-	goto LOOP_IF
+	JMP LOOP_IF
 
 LOOP_END:
 

--- a/ch3-asm/ch3-05-control-flow.md
+++ b/ch3-asm/ch3-05-control-flow.md
@@ -213,8 +213,10 @@ LOOP_END:
 下面用汇编语言重新实现LoopAdd函数
 
 ```
+#include "textflag.h"
+
 // func LoopAdd(cnt, v0, step int) int
-TEXT ·LoopAdd(SB),  $0-32
+TEXT ·LoopAdd(SB), NOSPLIT,  $0-32
 	MOVQ cnt+0(FP), AX   // cnt
 	MOVQ v0+8(FP), BX    // v0/result
 	MOVQ step+16(FP), CX // step


### PR DESCRIPTION
fix errors.

不知道为什么，这个标志`NOSPLIT` 不可以有，报错如下：
```
# mypkg/xch3/ch304/tmain
xch3\ch304\tmain\main_amd64.s:37: illegal or missing addressing mode for symbol NOSPLIT
asm: assembly of xch3\ch304\tmain\main_amd64.s failed

```

然后 汇编里面应该是没有goto指令吧。。goto应该是JMP。

