### PR TITLE
Update ch6-02-lock.md

### DIFF
--- a/ch6-cloud/ch6-02-lock.md
+++ b/ch6-cloud/ch6-02-lock.md
@@ -176,7 +176,7 @@ func incr() {
 	// counter ++
 	getResp := client.Get(counterKey)
 	cntValue, err := getResp.Int64()
-	if err == nil {
+	if err == nil || err == redis.Nil {
 		cntValue++
 		resp := client.Set(counterKey, cntValue, 0)
 		_, err := resp.Result()


### PR DESCRIPTION
如果redis没有"counter"这个key,  getResp.Int64()会返回redis.Nil导致"counter"key无法设置

提示：解决了什么问题，也可以讲下理由。
