### PR TITLE
fix bug call wrong function in example

### DIFF
--- a/ch6-cloud/ch6-07-crawler.md
+++ b/ch6-cloud/ch6-07-crawler.md
@@ -211,9 +211,8 @@ func initHIJKLCollector() *colly.Collector {
 }
 
 func init() {
-	domain2Collector["www.abcdefg.com"] = initV2exCollector()
-	domain2Collector["www.hijklmn.com"] = initV2fxCollector()
-
+	domain2Collector["www.abcdefg.com"] = initABCDECollector()
+	domain2Collector["www.hijklmn.com"] = initHIJKLCollector()
 	var err error
 	nc, err = nats.Connect(natsURL)
 	if err != nil {os.Exit(1)}
@@ -270,8 +269,8 @@ func initV2fxCollector() *colly.Collector {
 }
 
 func init() {
-	domain2Collector["www.abcdefg.com"] = initABCDECollector()
-	domain2Collector["www.hijklmn.com"] = initHIJKLCollector()
+	domain2Collector["www.abcdefg.com"] = initV2exCollector()
+	domain2Collector["www.hijklmn.com"] = initV2fxCollector()
 
 	var err error
 	nc, err = nats.Connect(natsURL)


### PR DESCRIPTION
In ch6-07-crawler, two examples call the wrong function name.

Example 6.7.3 should call `initABCDECollector` and `initHIJKLCollector`.
Example 6.7.4 should call `initV2exCollector` and `initV2fxCollector`.
 
