### PR TITLE
fix issue#500

### DIFF
--- a/ch4-rpc/ch4-05-grpc-hack.md
+++ b/ch4-rpc/ch4-05-grpc-hack.md
@@ -269,10 +269,10 @@ func (a *Authentication) Auth(ctx context.Context) error {
 	var appid string
 	var appkey string
 
-	if val, ok := md["login"]; ok { appid = val[0] }
+	if val, ok := md["user"]; ok { appid = val[0] }
 	if val, ok := md["password"]; ok { appkey = val[0] }
 
-	if appid != a.Login || appkey != a.Password {
+	if appid != a.User || appkey != a.Password {
 		return grpc.Errorf(codes.Unauthenticated, "invalid token")
 	}
 


### PR DESCRIPTION
解决了 issue#500，4.5.2 中的 Auth() 方法中的 Authentication 类型并没有 Login 字段，并且 `md` 对象中也没有以 `login` 为 key 的 value 的问题