### PR TITLE
Update ch5-03-middleware.md

### DIFF
--- a/ch5-web/ch5-03-middleware.md
+++ b/ch5-web/ch5-03-middleware.md
@@ -233,8 +233,10 @@ type Router struct {
 	mux map[string] http.Handler
 }
 
-func NewRouter() *Router{
-	return &Router{}
+func NewRouter() *Router {
+	return &Router{
+		mux: make(map[string]http.Handler),
+	}
 }
 
 func (r *Router) Use(m middleware) {


### PR DESCRIPTION
修复5.3.3 示例代码
nil map panic: assignment to entry in nil map

