### PR TITLE
fix falseValue in ch3-03-const-and-var

### DIFF
--- a/ch3-asm/ch3-03-const-and-var.md
+++ b/ch3-asm/ch3-03-const-and-var.md
@@ -138,7 +138,7 @@ GLOBL ·boolValue(SB),$1   // 未初始化
 GLOBL ·trueValue(SB),$1   // var trueValue = true
 DATA ·trueValue(SB)/1,$1  // 非 0 均为 true
 
-GLOBL ·falseValue(SB),$1  // var falseValue = true
+GLOBL ·falseValue(SB),$1  // var falseValue = false
 DATA ·falseValue(SB)/1,$0
 ```
 


### PR DESCRIPTION
[3.3.2.2 bool型变量](https://github.com/chai2010/advanced-go-programming-book/blob/master/ch3-asm/ch3-03-const-and-var.md#3322-bool%E5%9E%8B%E5%8F%98%E9%87%8F) 小节中，对 falseValue 符号内存初始化为 0，对应变量赋值应为 false