### PR TITLE
Update ch1-05-mem.md

### DIFF
--- a/ch1-basic/ch1-05-mem.md
+++ b/ch1-basic/ch1-05-mem.md
@@ -367,7 +367,7 @@ func main() {
 	for _, w := range work {
 		limit <- 1
 		go func(w func()) {
-			defer <-limit
+			defer func() { <-limit }()
 			w()
 		}(w)
 	}

--- a/ch1-basic/ch1-05-mem.md
+++ b/ch1-basic/ch1-05-mem.md
@@ -365,11 +365,11 @@ var work = []func(){
 
 func main() {
 	for _, w := range work {
+		limit <- 1
 		go func(w func()) {
-			limit <- 1
 			w()
-			<-limit
 		}(w)
+		<-limit
 	}
 	select{}
 }

--- a/ch1-basic/ch1-05-mem.md
+++ b/ch1-basic/ch1-05-mem.md
@@ -367,9 +367,9 @@ func main() {
 	for _, w := range work {
 		limit <- 1
 		go func(w func()) {
+			defer <-limit
 			w()
 		}(w)
-		<-limit
 	}
 	select{}
 }


### PR DESCRIPTION
fix 1.5.6 max goroutine number

书中这里实际上并没有控制最大协程数量，只是保证了在同一个时间内，只有3个协程可以执行w()函数，应该将通道的读写放在创建协程的前后