### PR TITLE
Fix syntax error of example code in ch1-basic/ch1-04-func-method-interface.md

### DIFF
--- a/ch1-basic/ch1-04-func-method-interface.md
+++ b/ch1-basic/ch1-04-func-method-interface.md
@@ -152,7 +152,7 @@ func f(x int) *int {
 }
 
 func g() int {
-	x = new(int)
+	x := new(int)
 	return *x
 }
 ```


### PR DESCRIPTION
修复变量声明语法错误