### PR TITLE
Update ch2-03-cgo-types.md

### DIFF
--- a/ch2-cgo/ch2-03-cgo-types.md
+++ b/ch2-cgo/ch2-03-cgo-types.md
@@ -340,7 +340,7 @@ func main() {
 	arr0Hdr.Cap = 10
 
 	// 通过切片语法转换
-	arr1 := (*[31]byte)(unsafe.Pointer(&C.arr[0]))[:10:10]
+	arr1 := (*[10]byte)(unsafe.Pointer(&C.arr[0]))[:10:10]
 
 	var s0 string
 	var s0Hdr = (*reflect.StringHeader)(unsafe.Pointer(&s0))
@@ -348,7 +348,7 @@ func main() {
 	s0Hdr.Len = int(C.strlen(C.s))
 
 	sLen := int(C.strlen(C.s))
-    	s1 := string((*[31]byte)(unsafe.Pointer(C.s))[:sLen:sLen])
+    	s1 := string((*[5]byte)(unsafe.Pointer(C.s))[:sLen:sLen])
 }
 ```
 


### PR DESCRIPTION
直接通过指针做强制类型转化，那么指定的 ```数组``` 大小不应该超过原先的 ```数组``` 大小，否则会出现访问到意外的数据。

